### PR TITLE
Add modular scraper with Indeed GraphQL parsing

### DIFF
--- a/scrapers/base.py
+++ b/scrapers/base.py
@@ -1,0 +1,21 @@
+import requests
+from typing import Optional, Dict, Any
+
+class BaseScraper:
+    """Simple base scraper supporting optional proxies."""
+
+    def __init__(self, proxies: Optional[Dict[str, str]] = None):
+        self.session = requests.Session()
+        self.proxies = proxies or {}
+
+    def get(self, url: str, **kwargs) -> requests.Response:
+        """Perform GET request using the current session and proxies."""
+        response = self.session.get(url, proxies=self.proxies, **kwargs)
+        response.raise_for_status()
+        return response
+
+    def post(self, url: str, data: Any = None, json: Any = None, **kwargs) -> requests.Response:
+        """Perform POST request using the current session and proxies."""
+        response = self.session.post(url, data=data, json=json, proxies=self.proxies, **kwargs)
+        response.raise_for_status()
+        return response

--- a/scrapers/indeed.py
+++ b/scrapers/indeed.py
@@ -1,0 +1,62 @@
+import json
+from typing import Generator, Dict, Any
+from bs4 import BeautifulSoup
+
+from .base import BaseScraper
+
+
+class IndeedScraper(BaseScraper):
+    """Scraper with two approaches: GraphQL API and standard HTML scraping."""
+
+    GRAPHQL_ENDPOINT = "https://www.indeed.com/graphql"
+
+    def search_graphql(self, query: str, location: str, start: int = 0, limit: int = 10) -> Generator[Dict[str, Any], None, None]:
+        """Yield jobs from Indeed GraphQL API."""
+        payload = {
+            "operationName": "JobSearch",
+            "variables": {
+                "query": query,
+                "location": location,
+                "start": start,
+                "limit": limit,
+            },
+            "query": """
+            query JobSearch($query: String!, $location: String!, $start: Int!, $limit: Int!) {
+              jobsearch(query: $query, location: $location, start: $start, limit: $limit) {
+                jobs {
+                  jobkey
+                  companyName
+                  formattedLocation
+                  jobTitle
+                }
+              }
+            }
+            """
+        }
+        response = self.post(self.GRAPHQL_ENDPOINT, json=payload, headers={"Content-Type": "application/json"})
+        data = response.json()
+        jobs = data.get("data", {}).get("jobsearch", {}).get("jobs", [])
+        for job in jobs:
+            yield {
+                "id": job.get("jobkey"),
+                "title": job.get("jobTitle"),
+                "company": job.get("companyName"),
+                "location": job.get("formattedLocation"),
+            }
+
+    def search_scrape(self, query: str, location: str, start: int = 0) -> Generator[Dict[str, Any], None, None]:
+        """Scrape Indeed search result HTML."""
+        url = f"https://www.indeed.com/jobs?q={query}&l={location}&start={start}"
+        response = self.get(url, headers={"User-Agent": "Mozilla/5.0"})
+        soup = BeautifulSoup(response.text, "lxml")
+        for card in soup.select("div.job_seen_beacon"):
+            jobkey = card.find("a", {"data-jk": True})
+            title_el = card.select_one("h2.jobTitle span")
+            company_el = card.select_one("span[data-testid='company-name']")
+            location_el = card.select_one("div[data-testid='text-location'] span")
+            yield {
+                "id": jobkey.get("data-jk") if jobkey else None,
+                "title": title_el.text.strip() if title_el else None,
+                "company": company_el.text.strip() if company_el else None,
+                "location": location_el.text.strip() if location_el else None,
+            }

--- a/tests/test_indeed.py
+++ b/tests/test_indeed.py
@@ -1,0 +1,57 @@
+import unittest
+from unittest.mock import patch, Mock
+
+from scrapers.indeed import IndeedScraper
+
+
+SAMPLE_GRAPHQL_RESPONSE = {
+    "data": {
+        "jobsearch": {
+            "jobs": [
+                {
+                    "jobkey": "123",
+                    "jobTitle": "Software Engineer",
+                    "companyName": "Acme",
+                    "formattedLocation": "Remote"
+                },
+                {
+                    "jobkey": "456",
+                    "jobTitle": "Data Scientist",
+                    "companyName": "Beta",
+                    "formattedLocation": "NY"
+                }
+            ]
+        }
+    }
+}
+
+SAMPLE_HTML = """
+<div class='job_seen_beacon'>
+    <a data-jk='789'></a>
+    <h2 class='jobTitle'><span>Developer</span></h2>
+    <span data-testid='company-name'>Gamma</span>
+    <div data-testid='text-location'><span>CA</span></div>
+</div>
+"""
+
+
+class TestIndeedScraper(unittest.TestCase):
+    def test_search_graphql_parsing(self):
+        scraper = IndeedScraper()
+        with patch.object(scraper, 'post', return_value=Mock(json=lambda: SAMPLE_GRAPHQL_RESPONSE)):
+            results = list(scraper.search_graphql('dev', 'remote'))
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0]['id'], '123')
+        self.assertEqual(results[1]['company'], 'Beta')
+
+    def test_search_scrape_parsing(self):
+        scraper = IndeedScraper()
+        mock_response = Mock(text=SAMPLE_HTML)
+        with patch.object(scraper, 'get', return_value=mock_response):
+            results = list(scraper.search_scrape('dev', 'remote'))
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]['company'], 'Gamma')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- introduce `scrapers` package with a minimal `BaseScraper`
- implement `IndeedScraper` supporting GraphQL and HTML parsing
- add unit tests verifying parsing logic for both approaches

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -v tests`
